### PR TITLE
[WEB-4243] Icon button alignment variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goodparty-styleguide",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goodparty-styleguide",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodparty-styleguide",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,33 +30,43 @@ const buttonVariants = cva(
         medium: "h-10 px-5 py-2.5 button-text-large has-[>svg]:px-4",
         large: "h-12 px-6 py-3 button-text-large has-[>svg]:px-5",
       },
+      iconPosition: {
+        left: "", // Default flex direction
+        right: "flex-row-reverse",
+      },
     },
     defaultVariants: {
       variant: "default",
       size: "medium",
+      iconPosition: "left",
     },
   }
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
-  const Comp = asChild ? Slot : "button"
-
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+  icon?: React.ReactNode
 }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, iconPosition, asChild = false, icon, children, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, iconPosition, className }))}
+        ref={ref}
+        {...props}
+      >
+        {icon}
+        {children}
+      </Comp>
+    )
+  }
+)
+
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -82,13 +82,24 @@ export const WithIcon: Story = {
   args: {
     children: 'Download',
     variant: 'default',
+    icon: <DownloadIcon className="h-4 w-4" />,
   },
+}
+
+export const IconPlacement: Story = {
   render: (args) => (
-    <Button {...args}>
-      <DownloadIcon className="mr-2 h-4 w-4" />
-      {args.children}
-    </Button>
+    <div className="flex flex-col gap-4 items-start">
+      <Button {...args} icon={<DownloadIcon className="h-4 w-4" />} iconPosition="left">
+        Icon Left
+      </Button>
+      <Button {...args} icon={<DownloadIcon className="h-4 w-4" />} iconPosition="right">
+        Icon Right
+      </Button>
+    </div>
   ),
+  args: {
+    variant: 'default',
+  }
 }
 
 export const Sizes: Story = {


### PR DESCRIPTION
Icons can now be aligned left or right of button text. Default icon alignment is left which matches previous functionality. 

Changes are backwards compatible.  No updates required to existing components.

NPM package minor version bump since this adds new functionality.

Button story updated with examples:
![CleanShot 2025-06-04 at 09 41 40](https://github.com/user-attachments/assets/8dbe1d96-f135-4529-9eda-6c9c25ac4b3f)
