### PR TITLE
Add `"use client"` directive to prevent Turbopack compile error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goodparty-styleguide",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goodparty-styleguide",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodparty-styleguide",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 import * as LabelPrimitive from '@radix-ui/react-label'
 import { Slot } from '@radix-ui/react-slot'


### PR DESCRIPTION
### Problem

1. **Breaking build in consuming Next 15 apps**  
   When the style-guide is installed in a Next.js 15 project (Turbopack), the build fails with:

   ```
   Export Controller doesn't exist in target module react-hook-form/dist/react-server.esm.mjs
   ```

2. **Root cause**  
   * `src/components/ui/form.tsx` imports and re-exports `Controller`, `FormProvider`, `useFormContext`, etc. from `react-hook-form`.  
   * Because the file lacked a `"use client"` directive, Next/Turbopack treated it as a **Server Component** and therefore resolved the **server-only entry-point** of `react-hook-form`, which omits those exports.

---

### Solution

Add the `"use client"` directive at the top of `src/components/ui/form.tsx` so that:

* Turbopack compiles the file as a **Client Component**.
* The normal browser bundle of `react-hook-form` is used, where `Controller`, `FormProvider`, and hooks exist.
* Builds in downstream Next.js apps succeed.

```diff
+ 'use client'
+
  import * as React from 'react'
  import * as LabelPrimitive from '@radix-ui/react-label'
  ...
```

---

### Follow-up

* Published a patch release (e.g., `v1.3.1`) so https://github.com/thegoodparty/gp-marketing/ can update.